### PR TITLE
force quote all non-numeric fields

### DIFF
--- a/csvdedupe/csvhelpers.py
+++ b/csvdedupe/csvhelpers.py
@@ -36,8 +36,8 @@ def preProcess(column):
 
 def readData(input_file, field_names, prefix=None):
     """
-    Read in our data from a CSV file and create a dictionary of records, 
-    where the key is a unique record ID and each value is a dict 
+    Read in our data from a CSV file and create a dictionary of records,
+    where the key is a unique record ID and each value is a dict
     of the row fields.
 
     **Currently, dedupe depends upon records' unique ids being integers
@@ -46,7 +46,7 @@ def readData(input_file, field_names, prefix=None):
     """
 
     data = {}
-    
+
     reader = csv.DictReader(StringIO(input_file))
     for i, row in enumerate(reader):
         clean_row = {k: preProcess(v) for (k, v) in row.items() if k is not None}
@@ -62,7 +62,7 @@ def readData(input_file, field_names, prefix=None):
 # ## Writing results
 def writeResults(clustered_dupes, input_file, output_file):
 
-    # Write our original data back out to a CSV with a new column called 
+    # Write our original data back out to a CSV with a new column called
     # 'Cluster ID' which indicates which records refer to each other.
 
     logging.info('saving results to: %s' % output_file)
@@ -74,7 +74,7 @@ def writeResults(clustered_dupes, input_file, output_file):
 
     unique_record_id = cluster_id + 1
 
-    writer = csv.writer(output_file)
+    writer = csv.writer(output_file, delimiter=',',quotechar='"', quoting=csv.QUOTE_NONNUMERIC)
 
     reader = csv.reader(StringIO(input_file))
 
@@ -95,7 +95,7 @@ def writeResults(clustered_dupes, input_file, output_file):
 # ## Writing results
 def writeUniqueResults(clustered_dupes, input_file, output_file):
 
-    # Write our original data back out to a CSV with a new column called 
+    # Write our original data back out to a CSV with a new column called
     # 'Cluster ID' which indicates which records refer to each other.
 
     logging.info('saving unique results to: %s' % output_file)
@@ -107,7 +107,7 @@ def writeUniqueResults(clustered_dupes, input_file, output_file):
 
     unique_record_id = cluster_id + 1
 
-    writer = csv.writer(output_file)
+    writer = csv.writer(output_file, delimiter=',',quotechar='"', quoting=csv.QUOTE_NONNUMERIC)
 
     reader = csv.reader(StringIO(input_file))
 
@@ -154,7 +154,7 @@ def writeLinkedResults(clustered_pairs, input_1, input_2, output_file,
         seen_1.add(index_1)
         seen_2.add(index_2)
 
-    writer = csv.writer(output_file)
+    writer = csv.writer(output_file, delimiter=',',quotechar='"', quoting=csv.QUOTE_NONNUMERIC)
     writer.writerow(row_header)
 
     for matches in matched_records:
@@ -223,13 +223,13 @@ class CSVCommand(object) :
             help='CSV file to store deduplication results')
         self.parser.add_argument('--skip_training', action='store_true',
             help='Skip labeling examples by user and read training from training_files only')
-        self.parser.add_argument('--training_file', type=str, 
+        self.parser.add_argument('--training_file', type=str,
             help='Path to a new or existing file consisting of labeled training examples')
         self.parser.add_argument('--settings_file', type=str,
             help='Path to a new or existing file consisting of learned training settings')
-        self.parser.add_argument('--sample_size', type=int, 
+        self.parser.add_argument('--sample_size', type=int,
             help='Number of random sample pairs to train off of')
-        self.parser.add_argument('--recall_weight', type=int, 
+        self.parser.add_argument('--recall_weight', type=int,
             help='Threshold that will maximize a weighted average of our precision and recall')
         self.parser.add_argument('-v', '--verbose', action='count', default=0)
 


### PR DESCRIPTION
Implicit default's [csv.QUOTE_MINIMAL](https://docs.python.org/3.5/library/csv.html#csv.QUOTE_MINIMAL) wasn't working somehow.

Replaced by [csv.QUOTE_NONNUMERIC](https://docs.python.org/3.5/library/csv.html#csv.QUOTE_NONNUMERIC).