### PR TITLE
Support latitude/longitude matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,40 @@ Or
                         Delimiting character of the input CSV file (default: ,)
   * `-h`, `--help`            show help message and exit
 
+## Field Definitions & Types
+
+When providing a JSON config file, you can include definitions for each field that tell csvdedupe what _type_ of data the field contains. 
+
+A basic definition for a single field looks like this:
+
+    {"field": "name", "type": "String"}
+    
+The dedupe docs include a [handy reference of all types and what they mean](https://dedupe.io/developers/library/en/latest/Variable-definition.html).
+
+### Latitude & Longitude
+
+When working with geographic points, it's necessary to provide field defintions that match the format of your data. Otherwise, csvdedupe may treat your lat/long fields as text and match in an unexpected way. 
+
+* For **one field containing both latitude and longitude**, specify `LatLong` or `LongLat` depending on the order. This expects a field with the coordinates separated by some (any) non-numeric characters, so formats like `-122.23,46.42`, `-122.23, 46.42`, and `-122.23 46.42` will all work.
+
+        {
+          "field_names": ["coordinates"],
+          "field_definition" : [{"field" : "coordinates", "type" : "LatLong"}],
+          ...more config
+        }
+
+
+* For **latitude and longitude in separate fields**, include separate `Latitude` and `Longitude` definitions. Internally, these are squished together into a single `LatLong` field, so you'll see them as `__LatLong` when training.
+
+        {
+          "field_names": ["lat", "lng"],
+          "field_definition" : [
+            {"field" : "lat", "type" : "Latitude"},
+            {"field" : "lng", "type" : "Longitude"}
+          ],
+          ...more config
+        }
+
 ## Training
 
 The _secret sauce_ of csvdedupe is human input. In order to figure out the best rules to deduplicate a set of data, you must give it a set of labeled examples to learn from.

--- a/csvdedupe/csvdedupe.py
+++ b/csvdedupe/csvdedupe.py
@@ -48,7 +48,7 @@ class CSVDedupe(csvhelpers.CSVCommand) :
             except KeyError:
                 raise self.parser.error("You must provide field_names")
         else :
-            self.field_names = [self.field_def['field'] 
+            self.field_names = [field_def['field']
                                 for field_def in self.field_definition]
 
         self.destructive = self.configuration.get('destructive', False)

--- a/csvdedupe/csvdedupe.py
+++ b/csvdedupe/csvdedupe.py
@@ -25,7 +25,7 @@ class CSVDedupe(csvhelpers.CSVCommand) :
                     # We need to get control of STDIN again.
                     # This is a UNIX/Mac OSX solution only
                     # http://stackoverflow.com/questions/7141331/pipe-input-to-python-program-and-later-get-input-from-user
-                    # 
+                    #
                     # Same question has a Windows solution
                     sys.stdin = open('/dev/tty')  # Unix only solution,
                 else:
@@ -94,7 +94,7 @@ class CSVDedupe(csvhelpers.CSVCommand) :
 
             fields = {variable.field for variable in deduper.data_model.primary_fields}
             unique_d, parents = exact_matches(data_d, fields)
-                
+
         else:
             # # Create a new deduper object and pass our data model to it.
             deduper = dedupe.Dedupe(self.field_definition)
@@ -115,7 +115,7 @@ class CSVDedupe(csvhelpers.CSVCommand) :
 
         # ## Clustering
 
-        # Find the threshold that will maximize a weighted average of our precision and recall. 
+        # Find the threshold that will maximize a weighted average of our precision and recall.
         # When we set the recall weight to 2, we are saying we care twice as much
         # about recall as we do precision.
         #

--- a/csvdedupe/csvhelpers.py
+++ b/csvdedupe/csvhelpers.py
@@ -23,7 +23,7 @@ import argparse
 
 def preProcess(column):
     """
-    Do a little bit of data cleaning. Things like casing, extra spaces, 
+    Do a little bit of data cleaning. Things like casing, extra spaces,
     quotes and new lines are ignored.
     """
     column = re.sub('  +', ' ', column)
@@ -36,8 +36,8 @@ def preProcess(column):
 
 def readData(input_file, field_names, delimiter=',', prefix=None):
     """
-    Read in our data from a CSV file and create a dictionary of records, 
-    where the key is a unique record ID and each value is a dict 
+    Read in our data from a CSV file and create a dictionary of records,
+    where the key is a unique record ID and each value is a dict
     of the row fields.
 
     **Currently, dedupe depends upon records' unique ids being integers
@@ -46,7 +46,7 @@ def readData(input_file, field_names, delimiter=',', prefix=None):
     """
 
     data = {}
-    
+
     reader = csv.DictReader(StringIO(input_file),delimiter=delimiter)
     for i, row in enumerate(reader):
         clean_row = {k: preProcess(v) for (k, v) in row.items() if k is not None}
@@ -62,7 +62,7 @@ def readData(input_file, field_names, delimiter=',', prefix=None):
 # ## Writing results
 def writeResults(clustered_dupes, input_file, output_file):
 
-    # Write our original data back out to a CSV with a new column called 
+    # Write our original data back out to a CSV with a new column called
     # 'Cluster ID' which indicates which records refer to each other.
 
     logging.info('saving results to: %s' % output_file)
@@ -95,7 +95,7 @@ def writeResults(clustered_dupes, input_file, output_file):
 # ## Writing results
 def writeUniqueResults(clustered_dupes, input_file, output_file):
 
-    # Write our original data back out to a CSV with a new column called 
+    # Write our original data back out to a CSV with a new column called
     # 'Cluster ID' which indicates which records refer to each other.
 
     logging.info('saving unique results to: %s' % output_file)
@@ -232,13 +232,13 @@ class CSVCommand(object) :
             help='CSV file to store deduplication results')
         self.parser.add_argument('--skip_training', action='store_true',
             help='Skip labeling examples by user and read training from training_files only')
-        self.parser.add_argument('--training_file', type=str, 
+        self.parser.add_argument('--training_file', type=str,
             help='Path to a new or existing file consisting of labeled training examples')
         self.parser.add_argument('--settings_file', type=str,
             help='Path to a new or existing file consisting of learned training settings')
-        self.parser.add_argument('--sample_size', type=int, 
+        self.parser.add_argument('--sample_size', type=int,
             help='Number of random sample pairs to train off of')
-        self.parser.add_argument('--recall_weight', type=int, 
+        self.parser.add_argument('--recall_weight', type=int,
             help='Threshold that will maximize a weighted average of our precision and recall')
         self.parser.add_argument('-d', '--delimiter', type=str,
             help='Delimiting character of the input CSV file', default=',')

--- a/csvdedupe/csvlink.py
+++ b/csvdedupe/csvlink.py
@@ -112,14 +112,14 @@ class CSVLink(csvhelpers.CSVCommand):
                                                           % self.settings_file)
             with open(self.settings_file, 'rb') as f:
                 deduper = dedupe.StaticRecordLink(f)
-                
+
 
             fields = {variable.field for variable in deduper.data_model.primary_fields}
             (nonexact_1,
              nonexact_2,
              exact_pairs) = exact_matches(data_1, data_2, fields)
-            
-            
+
+
         else:
             # # Create a new deduper object and pass our data model to it.
             deduper = dedupe.RecordLink(self.field_definition)
@@ -142,7 +142,7 @@ class CSVLink(csvhelpers.CSVCommand):
 
         # ## Clustering
 
-        # Find the threshold that will maximize a weighted average of our precision and recall. 
+        # Find the threshold that will maximize a weighted average of our precision and recall.
         # When we set the recall weight to 2, we are saying we care twice as much
         # about recall as we do precision.
         #
@@ -189,7 +189,7 @@ def exact_matches(data_1, data_2, match_fields):
 
     for key, record in data_1.items():
         record_hash = hash(tuple(record[f] for f in match_fields))
-        redundant[record_hash] = key        
+        redundant[record_hash] = key
 
     for key_2, record in data_2.items():
         record_hash = hash(tuple(record[f] for f in match_fields))
@@ -202,7 +202,7 @@ def exact_matches(data_1, data_2, match_fields):
 
     for key_1 in redundant.values():
         nonexact_1[key_1] = data_1[key_1]
-        
+
     return nonexact_1, nonexact_2, exact_pairs
 
 def launch_new_instance():

--- a/csvdedupe/csvlink.py
+++ b/csvdedupe/csvlink.py
@@ -70,12 +70,19 @@ class CSVLink(csvhelpers.CSVCommand):
         data_2 = {}
         # import the specified CSV file
 
-        data_1 = csvhelpers.readData(self.input_1, self.field_names_1,
-                                    delimiter=self.delimiter,
-                                    prefix='input_1')
-        data_2 = csvhelpers.readData(self.input_2, self.field_names_2,
-                                    delimiter=self.delimiter,
-                                    prefix='input_2')
+        data_1 = csvhelpers.readData(input_file=self.input_1,
+                                     field_names=self.field_names_1,
+                                     field_definition=self.field_definition,
+                                     delimiter=self.delimiter,
+                                     prefix='input_1')
+        data_2 = csvhelpers.readData(input_file=self.input_2,
+                                     field_names=self.field_names_2,
+                                     field_definition=self.field_definition,
+                                     delimiter=self.delimiter,
+                                     prefix='input_2')
+
+        internal_field_definition = csvhelpers.transformLatLongFieldDefinition(
+                self.field_definition)
 
         # sanity check for provided field names in CSV file
         for field in self.field_names_1:
@@ -100,7 +107,7 @@ class CSVLink(csvhelpers.CSVCommand):
         logging.info('imported %d rows from file 2', len(data_2))
 
         logging.info('using fields: %s' % [field['field']
-                                           for field in self.field_definition])
+                                           for field in internal_field_definition])
 
         # If --skip_training has been selected, and we have a settings cache still
         # persisting from the last run, use it in this next run.
@@ -122,7 +129,7 @@ class CSVLink(csvhelpers.CSVCommand):
 
         else:
             # # Create a new deduper object and pass our data model to it.
-            deduper = dedupe.RecordLink(self.field_definition)
+            deduper = dedupe.RecordLink(internal_field_definition)
 
             fields = {variable.field for variable in deduper.data_model.primary_fields}
             (nonexact_1,


### PR DESCRIPTION
I saw that #30 tried to add this, but relied too heavily on magic field names. This is a more in-depth stab at bringing nicer coordinate matching to csvdedupe. (This also includes the commit from #82, since nothing involving config files will run without it)

To achieve this, it's necessary to both transform the data we read from the CSV and to make an internal copy of the field definitions that we can bend to match what dedupe expects.

* For **one field containing both latitude and longitude**, the JSON config now supports both `LatLong` or `LongLat` types. They expect a field with the coordinates separated by some (any) non-numeric characters, so formats like `-122.23,46.42`, `-122.23, 46.42`, and `-122.23 46.42` will all work. 

    Behind the scenes, we split the field to the tuple of floats that dedupe expects. For the `LongLat` type, we reverse it to `LatLong` order and swap the internal type to `LatLong`.

* For **latitude and longitude in separate fields**, we add `Latitude` and `Longitude` convenience types. Internally, these are coalesced into a single `LatLong` field called `__LatLong`. 

    One side effect of this change is that the training UI will now show this combined field instead of the original field names, but I think that's a fairly minor tradeoff.