### PR TITLE
Fix delimiter from config being ignored

### DIFF
--- a/csvdedupe/csvhelpers.py
+++ b/csvdedupe/csvhelpers.py
@@ -241,7 +241,7 @@ class CSVCommand(object) :
         self.parser.add_argument('--recall_weight', type=int, 
             help='Threshold that will maximize a weighted average of our precision and recall')
         self.parser.add_argument('-d', '--delimiter', type=str,
-            help='Delimiting character of the input CSV file', default=',')
+            help='Delimiting character of the input CSV file (default: ","')
         self.parser.add_argument('-v', '--verbose', action='count', default=0)
 
 


### PR DESCRIPTION
Quick and dirty fix.
Problem was that there was default value of delimiter inserted into `args`. Values from `args` are used to override parameters from config file. This resulted in delimiter option in config being always overwritten with ',' .